### PR TITLE
Potential fix for code scanning alert no. 2: Missing JWT signature check

### DIFF
--- a/src/main/java/com/expensetracker/backend/security/jwt/JwtUtils.java
+++ b/src/main/java/com/expensetracker/backend/security/jwt/JwtUtils.java
@@ -65,7 +65,7 @@ public class JwtUtils {
             Jwts.parserBuilder()
                     .setSigningKey(key())
                     .build()
-                    .parse(authToken);
+                    .parseClaimsJws(authToken);
             return true;
         } catch (Exception e) {
             // Log lỗi nếu token không hợp lệ


### PR DESCRIPTION
Potential fix for [https://github.com/thanhpro0802/personal-expense-tracker-backend/security/code-scanning/2](https://github.com/thanhpro0802/personal-expense-tracker-backend/security/code-scanning/2)

To fix the problem:  
- Ensure that JWT signature validation is performed when checking token validity, not just parsing.
- In `validateJwtToken` (lines 63–75), replace `parse(authToken)` with `parseClaimsJws(authToken)`. This change enforces cryptographic validation of the JWT signature and ensures that only tokens with a valid signature (signed by the expected key) are accepted as valid.
- This fix is strictly local, does not affect the shape of any return value, and keeps the method's logic and structure unchanged except for the verification step.
- No new imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
