### PR TITLE
Potential fix for code scanning alert no. 1: Disabled Spring CSRF protection

### DIFF
--- a/src/main/java/com/expensetracker/backend/security/WebSecurityConfig.java
+++ b/src/main/java/com/expensetracker/backend/security/WebSecurityConfig.java
@@ -81,7 +81,7 @@ public class WebSecurityConfig {
     // Cấu hình HttpSecurity
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http.csrf(csrf -> csrf.disable())
+        http
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .exceptionHandling(exception -> exception.authenticationEntryPoint(unauthorizedHandler))
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))


### PR DESCRIPTION
Potential fix for [https://github.com/thanhpro0802/personal-expense-tracker-backend/security/code-scanning/1](https://github.com/thanhpro0802/personal-expense-tracker-backend/security/code-scanning/1)

**General fix:**  
To correct the vulnerability, CSRF protection should be enabled unless there is a clearly documented, valid reason to disable it for all endpoints (e.g., stateless REST APIs not serving browsers). In most applications interacting with browsers, Spring's default CSRF protection should remain active. If some endpoints (like certain API paths) are stateless and require CSRF to be disabled for those only, a targeted `.ignoringAntMatchers(...` approach can be used rather than fully disabling CSRF globally.

**Detailed fix:**  
Remove `.csrf(csrf -> csrf.disable())` from the `filterChain` method in `WebSecurityConfig.java`. This restores the default: CSRF protection is enabled. No other code changes are required if all API endpoints are expected to support CSRF. If you have some purely REST endpoints and want to selectively disable CSRF for those, use `.csrf(csrf -> csrf.ignoringRequestMatchers("/api/auth/**", ...))`. However, best practice is to keep CSRF enabled for browser-accessible endpoints.

**File/lines to change:**  
- File: `src/main/java/com/expensetracker/backend/security/WebSecurityConfig.java`
- Region: Method `filterChain` (remove or modify line 84).

**Needed:**  
- No new imports or method definitions needed, as this is just removal of a line.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
